### PR TITLE
Remove unused gradle dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,6 @@ buildscript {
 
     dependencies {
         classpath 'com.android.tools.build:gradle:3.2.1'
-        classpath 'com.novoda:bintray-release:0.9'
     }
 }
 


### PR DESCRIPTION
删掉了com.novoda:bintray-release，看了下项目里没有东西用这个，这个被废弃了，不删的话FingerprintPay项目编译报错
```
A problem occurred configuring project ':3rdparty:FingerprintIdentify'.
> Could not resolve all files for configuration ':3rdparty:FingerprintIdentify:classpath'.
   > Could not find com.novoda:bintray-release:0.9.
     Searched in the following locations:
       - https://dl.google.com/dl/android/maven2/com/novoda/bintray-release/0.9/bintray-release-0.9.pom
       - https://jcenter.bintray.com/com/novoda/bintray-release/0.9/bintray-release-0.9.pom
     Required by:
         project :3rdparty:FingerprintIdentify
```